### PR TITLE
fix: specify which metabolite to reuse instead of first by match bigg_id

### DIFF
--- a/src/Builder.jsx
+++ b/src/Builder.jsx
@@ -909,7 +909,7 @@ class Builder {
     while (true) {
       const mergedReaction = this.map.draw_one_added_reaction(
         added_reactions,
-        newlyAdded.map(reaction => reaction.bigg_id),
+        newlyAdded.map(reaction => reaction.id),
         reuseAllExisting
       )
       if (mergedReaction) {

--- a/src/Map.js
+++ b/src/Map.js
@@ -600,11 +600,10 @@ export default class Map {
       .map((reactionId) => this.cobra_model.reactions[reactionId])
       .reduce((accumulator, reaction) => accumulator.concat(Object.keys(reaction.metabolites)), [])
       .filter((metabolite) => this.isMetabolite.call(this, metabolite))
-      // TODO: reenable when primary nodes are detected correctly
-      // .filter((metabolite) => {
-      //   const nodes = this.bigg_index.getAll(metabolite)
-      //   return nodes.some((node) => node.node_is_primary)
-      // })
+      .filter((metabolite) => {
+        const nodes = this.bigg_index.getAll(metabolite)
+        return nodes.some((node) => node.node_is_primary)
+      })
     added = utils.findMap(reactionIds, (reactionId) => {
       return this.try_drawing_reaction.call(this, reactionId, previouslyAddedRactionsMetabolites)
     })

--- a/src/build.js
+++ b/src/build.js
@@ -174,11 +174,14 @@ export function newReaction (biggId, cobraReaction, cobraMetabolites,
   // set primary metabolites, and keep track of the total counts
   for (let metBiggId in newReaction.metabolites) {
     const metabolite = newReaction.metabolites[metBiggId]
+    const isMetabolite = cofactors.indexOf(utils.decompartmentalize(metabolite.bigg_id)[0]) === -1
     if (metabolite.coefficient < 0) {
-      metabolite.is_primary = metabolite.index === primaryReactantIndex
+      metabolite.is_primary = metabolite.index === primaryReactantIndex ||
+                              (isMetabolite && cobraMetabolites[metabolite.bigg_id].is_heterologous)
       metabolite.count = reactantCount
     } else {
-      metabolite.is_primary = metabolite.index === primaryProductIndex
+      metabolite.is_primary = metabolite.index === primaryProductIndex ||
+                              (isMetabolite && cobraMetabolites[metabolite.bigg_id].is_heterologous)
       metabolite.count = productCount
     }
   }


### PR DESCRIPTION
Bug: reactions got merged to a random `pi_c` metabolite in the center,
just because previously added reaction contained `pi_c`, and somewhere
else on the map, there was a primary `pi_c`