### PR TITLE
fix: keep measured reactions highlighted after applying the search

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -2325,6 +2325,8 @@ export default class Map {
 
   highlight (sel) {
     this.sel.selectAll('.highlight')
+      // Skip measured reactions to keep them highlighted during the search
+      .filter(el => !this.settings.get("reaction_highlight").includes(el.bigg_id))
       .classed('highlight', false)
     if (sel !== null) {
       sel.classed('highlight', true)

--- a/src/SearchBar.jsx
+++ b/src/SearchBar.jsx
@@ -147,6 +147,11 @@ class SearchBar extends Component {
   }
 
   close () {
+    // Reset highlights for measured reactions when closing the search bar
+    // in order to set initial styles back
+    const highlight_reaction_ids = this.props.map.settings.get("reaction_highlight")
+    this.props.map.clear_these_highlights()
+    this.props.map.set_these_highlights(highlight_reaction_ids)
     this.props.setDisplay(false)
   }
 


### PR DESCRIPTION
Fixes https://github.com/DD-DeCaF/scrum/issues/1161

Previously all highlights were cleared when the search was applied.
As we are using the glow to highlight measured reactions, now we are filtering them out.
If user was searching for one of the measured reactions, the color of its label was changed. For that reason we need to reset highlights when closing the search bar.