### PR TITLE
fix: consider scientific notation when parsing gene reaction rules

### DIFF
--- a/src/dataStyles.js
+++ b/src/dataStyles.js
@@ -14,9 +14,9 @@ const EXCESS_PARENS = /\(\s*(\S+)\s*\)/g
 const OR = /\s+or\s+/i
 const AND = /\s+and\s+/i
 // find ORs
-const OR_EXPRESSION = /(^|\()(\s*-?[0-9.]+\s+(?:or\s+-?[0-9.]+\s*)+)(\)|$)/ig
+const OR_EXPRESSION = /(^|\()(\s*-?[0-9.]+(?:[eE]-?[0-9]+)?\s+(?:or\s+-?[0-9.]+(?:[eE]-?[0-9]+)?\s*)+)(\)|$)/ig
 // find ANDS, respecting order of operations (and before or)
-const AND_EXPRESSION = /(^|\(|or\s)(\s*-?[0-9.]+\s+(?:and\s+-?[0-9.]+\s*)+)(\sor|\)|$)/ig
+const AND_EXPRESSION = /(^|\(|or\s)(\s*-?[0-9.]+(?:[eE]-?[0-9]+)?\s+(?:and\s+-?[0-9.]+(?:[eE]-?[0-9]+)?\s*)+)(\sor|\)|$)/ig
 
 function parseFloatOrNull (x) {
   // strict number casting


### PR DESCRIPTION
Part of `Visualize proteomics data` feature.
Currently, Escher doesn't consider scientific notation when parsing `gene reaction rule` (e.g. ` 0.2 or 2.45e-7 or 0.123`) and can't evaluate the rule. For that reason not all of the proteomics data is visualized.